### PR TITLE
Merge Feature/dynamic group to allow assignment of InventoryElement to Group at Run Time

### DIFF
--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -111,7 +111,6 @@ class ParentGroups(List["Group"]):
 
         self.append(group)
 
-
     def remove_group(self, group: "Group") -> None:
 
         if self.__contains__(group):
@@ -164,12 +163,10 @@ class InventoryElement(BaseAttributes):
             **super().dict(),
         }
 
-
     def add_to_group(self, group: "Group") -> None:
         self.groups.add_group(group)
 
     def remove_from_group(self, group: "Group") -> None:
-        #self.groups.remove(group)
         self.groups.remove_group(group)
 
 

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -105,6 +105,20 @@ class ParentGroups(List["Group"]):
         else:
             return any([value == g for g in self])
 
+    def add_group(self, group: "Group") -> None:
+        if self.__contains__(group):
+            return
+
+        self.append(group)
+
+
+    def remove_group(self, group: "Group") -> None:
+
+        if self.__contains__(group):
+            self.remove(group)
+        else:
+            raise ValueError(f"Group {group} key error")
+
 
 class InventoryElement(BaseAttributes):
     __slots__ = ("groups", "data", "connection_options")
@@ -151,6 +165,21 @@ class InventoryElement(BaseAttributes):
         }
 
 
+    def add_to_group(self, group: "Group") -> None:
+        self.groups.add_group(group)
+
+    def remove_from_group(self, group: "Group") -> None:
+        #self.groups.remove(group)
+        self.groups.remove_group(group)
+
+    def refresh(self):
+        super().__init__(
+            hostname=hostname,
+            port=port,
+            username=username,
+            password=password,
+            platform=platform,
+        )
 class Defaults(BaseAttributes):
     __slots__ = ("data", "connection_options")
 

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -105,18 +105,17 @@ class ParentGroups(List["Group"]):
         else:
             return any([value == g for g in self])
 
-    def add_group(self, group: "Group") -> None:
+    def add(self, group: "Group") -> None:
+        # only add the group if it doesn't exist
+        if not self.__contains__(group):
+            self.append(group)
+
+    def remove(self, group: "Group") -> None:
         if self.__contains__(group):
-            return
-
-        self.append(group)
-
-    def remove_group(self, group: "Group") -> None:
-
-        if self.__contains__(group):
-            self.remove(group)
+            # remove overrides the parent class so calling super()
+            super(ParentGroups, self).remove(group)
         else:
-            raise ValueError(f"Group {group} key error")
+            raise KeyError(group)
 
 
 class InventoryElement(BaseAttributes):
@@ -164,10 +163,10 @@ class InventoryElement(BaseAttributes):
         }
 
     def add_to_group(self, group: "Group") -> None:
-        self.groups.add_group(group)
+        self.groups.add(group)
 
     def remove_from_group(self, group: "Group") -> None:
-        self.groups.remove_group(group)
+        self.groups.remove(group)
 
 
 class Defaults(BaseAttributes):

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -172,14 +172,7 @@ class InventoryElement(BaseAttributes):
         #self.groups.remove(group)
         self.groups.remove_group(group)
 
-    def refresh(self):
-        super().__init__(
-            hostname=hostname,
-            port=port,
-            username=username,
-            password=password,
-            platform=platform,
-        )
+
 class Defaults(BaseAttributes):
     __slots__ = ("data", "connection_options")
 

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -558,6 +558,7 @@ class Test(object):
         g2 = inventory.Group(name="g2", groups=inventory.ParentGroups([g1]))
         g3 = inventory.Group(name="g3", groups=inventory.ParentGroups([g2]), data=data)
         h1 = inventory.Host(name="h1", groups=inventory.ParentGroups([g1, g2, g3]))
+        h2 = inventory.Host(name="h2")
         hosts = {"h1": h1, "h2": h2}
         groups = {"g1": g1, "g2": g2}
         inv = inventory.Inventory(hosts=hosts, groups=groups)

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -532,8 +532,8 @@ class Test(object):
         assert "dev3.group_2" in hosts_dict
 
     def test_add_group_to_host_runtime(self, inv):
-        orig_data = {"var1" : "val1"}
-        data = {"var3" : "val3"}
+        orig_data = {"var1": "val1"}
+        data = {"var3": "val3"}
         g1 = inventory.Group(name="g1", data=orig_data)
         g2 = inventory.Group(name="g2", groups=inventory.ParentGroups([g1]))
         g3 = inventory.Group(name="g3", groups=inventory.ParentGroups([g2]), data=data)
@@ -549,11 +549,11 @@ class Test(object):
 
         h1.add_to_group(g3)
         assert g3 in h1.groups
-        assert h1.get("var3", None) is "val3"
+        assert h1.get("var3", None) == "val3"
 
     def test_remove_group_from_host(self):
-        data = {"var3" : "val3"}
-        orig_data = {"var1" : "val1"}
+        data = {"var3": "val3"}
+        orig_data = {"var1": "val1"}
         g1 = inventory.Group(name="g1", data=orig_data)
         g2 = inventory.Group(name="g2", groups=inventory.ParentGroups([g1]))
         g3 = inventory.Group(name="g3", groups=inventory.ParentGroups([g2]), data=data)

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -544,7 +544,7 @@ class Test(object):
         inv = inventory.Inventory(hosts=hosts, groups=groups)
 
         assert "h1" in inv.hosts
-        assert g3 not in inv.hosts['h1'].groups
+        assert g3 not in inv.hosts["h1"].groups
         assert h1.get("var3", None) is None
 
         h1.add_to_group(g3)
@@ -564,7 +564,7 @@ class Test(object):
         inv = inventory.Inventory(hosts=hosts, groups=groups)
 
         assert "h1" in inv.hosts
-        assert g3 in inv.hosts['h1'].groups
+        assert g3 in inv.hosts["h1"].groups
         assert h1.get("var3") == "val3"
 
         h1.remove_from_group(g3)

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -558,7 +558,6 @@ class Test(object):
         g2 = inventory.Group(name="g2", groups=inventory.ParentGroups([g1]))
         g3 = inventory.Group(name="g3", groups=inventory.ParentGroups([g2]), data=data)
         h1 = inventory.Host(name="h1", groups=inventory.ParentGroups([g1, g2, g3]))
-        h2 = inventory.Host(name="h2")
         hosts = {"h1": h1, "h2": h2}
         groups = {"g1": g1, "g2": g2}
         inv = inventory.Inventory(hosts=hosts, groups=groups)
@@ -567,7 +566,13 @@ class Test(object):
         assert g3 in inv.hosts["h1"].groups
         assert h1.get("var3") == "val3"
 
+        g3.data["var3"] = "newval3"
+        assert h1.get("var3", None) == "newval3"
+
         h1.remove_from_group(g3)
         assert g3 not in h1.groups
         assert h1.get("var3", None) is None
         assert h1.get("var1", None) == "val1"
+
+        with pytest.raises(KeyError):
+            h1.remove_from_group(g3)


### PR DESCRIPTION
Update inventory to allow for the addition of groups to an Inventory Element at run time.

Added two methods to the InventoryElement:  add() & remove()

Added two methods to Host add_to_group() and remove_from_group()